### PR TITLE
Refactoring?

### DIFF
--- a/collections/findagrave.js
+++ b/collections/findagrave.js
@@ -1,6 +1,7 @@
 registerCollection({
   "url": "http://www.findagrave.com",
   "prepareUrl": function(url) {
+      return url;
   },
 });
 

--- a/collections/findagrave.js
+++ b/collections/findagrave.js
@@ -1,3 +1,23 @@
+registerCollection({
+  "url": "http://www.findagrave.com",
+  "prepareUrl": function(url) {
+  },
+});
+
+registerCollection({
+  "url": "http://findagrave.com",
+  "prepareUrl": function(url) {
+    return url.replace("http://findagrave.com", "http://www.findagrave.com");
+  },
+});
+
+registerCollection({
+  "url": "http://forums.findagrave.com",
+  "prepareUrl": function(url) {
+    return url.replace("http://forums.findagrave.com", "http://www.findagrave.com");
+  },
+});
+
 // Parse FindAGrave
 function parseFindAGrave(htmlstring, familymembers, relation) {
     relation = relation || "";

--- a/popup.js
+++ b/popup.js
@@ -160,6 +160,11 @@ function startsWithHTTP(url, match) {
     return url.startsWith(match);
 }
 
+var collections = new Array();
+var collection;
+function registerCollection(collection) {
+  collections.push(collection);
+}
 
 function loginProcess() {
 
@@ -169,15 +174,44 @@ function loginProcess() {
         checkAccount();
         chrome.tabs.getSelected(null, function (tab) {
             tablink = tab.url;
-            if (startsWithHTTP(tablink,"http://findagrave.com") || startsWithHTTP(tablink,"http://forums.findagrave.com")) {
-                tablink = tablink.replace("http://findagrave.com", "http://www.findagrave.com");
-                tablink = tablink.replace("http://forums.findagrave.com", "http://www.findagrave.com");
+
+            console.log(collections);
+            // Select collection
+            for (var i=0; i<collections.length; i++) {
+              if (startsWithHTTP(tablink, collections[i].url)) {
+                collection = collections[i];
+                break;
+              }
             }
+            if (collection == undefined) {
+              // TODO: display error
+              console.log("Could not find collection");
+            }
+            console.log("collection URL: "+collection.url);
+
+            // prepareUrl
+            if (collection.prepareUrl) {
+              tablink = collection.prepareUrl(tablink);
+            }
+
+            // TODO: which collection is that?
             if (startsWithHTTP(tablink,"http://www.ancestry.") && !startsWithHTTP(tablink,"http://www.ancestry.com") && tablink.contains("/genealogy/records/")) {
                 var ancestrystart = tablink.split("www.ancestry.");
                 //Replace domain for other countries, such as http://www.ancestry.ca/genealogy/records/abraham-knowlton_17477348
                 tablink = ancestrystart[0] + "www.ancestry.com" + ancestrystart[1].substring(ancestrystart[1].indexOf("/"));
             }
+
+            // Parse data
+            if (collection.parseData) {
+                console.log("Going to parse data now");
+                collection.parseData();
+            } else {
+                console.log("No parseData function");
+                setMessage("#f9acac", 'SmartCopy does not currently support parsing this page / site / collection.');
+                document.querySelector('#loginspinner').style.display = "none";
+            }
+
+            // TODO: migrate all this to parseData()
             if (startsWithMH(tablink, "research/collection") || startsWithMH(tablink, "research/record") || (startsWithHTTP(tablink,"http://www.findagrave.com") && !tablink.contains("page=gsr")) ||
                 startsWithHTTP(tablink,"http://www.wikitree.com") || startsWithHTTP(tablink,"http://trees.ancestry.") || startsWithHTTP(tablink,"http://person.ancestry.") || startsWithHTTP(tablink,"http://www.werelate.org/wiki/Person") ||
                 (validRootsWeb(tablink) && tablink.contains("id=")) || (startsWithHTTP(tablink,"http://records.ancestry.com") && tablink.contains("pid=")) || startsWithHTTP(tablink,"http://www.ancestry.com/genealogy/records/") ||
@@ -712,7 +746,10 @@ function loadPage(request) {
                     $("#genilinkdesc").attr('title', "Geni: " + geni_return.name + dateinfo);
                 });
                 console.log("Parsing Family...");
-                if (tablink.contains("/collection-") || tablink.contains("/research/record-")) {
+                // generic call
+                if (collection.parseData) {
+                    collection.parseProfileData(request.source, true);
+                } else if (tablink.contains("/collection-") || tablink.contains("/research/record-")) {
                     parseSmartMatch(request.source, true);
                 } else if (startsWithHTTP(tablink,"http://www.findagrave.com")) {
                     parseFindAGrave(request.source, true);
@@ -1043,10 +1080,15 @@ function setMessage(color, messagetext) {
 }
 
 function getPageCode() {
+    console.log("Collection URL is still: "+collection.url);
     if (loggedin && exists(accountinfo)) {
         document.querySelector('#loginspinner').style.display = "none";
         document.getElementById("smartcopy-container").style.display = "block";
         document.getElementById("loading").style.display = "block";
+
+        if (collection.getPageCode) {
+          collection.getPageCode();
+        }
 
         if ((startsWithHTTP(tablink,"http://www.myheritage.com/site-family-tree-") || startsWithHTTP(tablink,"https://www.myheritage.com/site-family-tree-")) && !tablink.endsWith("-info")) {
             setMessage("#f8ff86", 'Unable to read in tree view.  Please select the Profile page instead.');
@@ -2218,7 +2260,9 @@ function addHistory(id, itemId, name, data) {
 
 function supportedCollection() {
     var expenabled = $('#exponoffswitch').prop('checked');
-    if (!expenabled && startsWithHTTP(tablink,"https://expermientalsite.com")) {
+    if (collection) {
+      return true;
+    } else if (!expenabled && startsWithHTTP(tablink,"https://expermientalsite.com")) {
         return false;
     } else return tablink.contains("/collection-") || tablink.contains("research/record-") || startsWithHTTP(tablink,"http://www.findagrave.com") ||
         startsWithHTTP(tablink,"http://www.wikitree.com/") || validRootsWeb(tablink) ||


### PR DESCRIPTION
So I've had a go at implementing a Filae collection parser, and I've found that there's lots of hardcoding and duplicated logic to use (especially when it comes to all the if/else if/else in `popup.js`).

It seems to me that adding more collection parsers (Filae, Geneanet, etc.) would be useful but will only increase the complexity in `popup.js`, so I suggest it might be good to refactor the existing code before that.

My take would be to have the collections register themselves with the extension. At first, they could be providing callback methods to replace all the if/else if/else blocks. As a second step, I think it would be even more elegant to have collection parsers declare XPath expressions for profile fields.

I'm willing to help with the refactoring to get this extension even more useful.