### PR TITLE
Check other language names

### DIFF
--- a/content.js
+++ b/content.js
@@ -358,74 +358,142 @@ function selfCheck(familyset) {
             }
 
             if (namecheckoption) {
-                var namevaluecheck = [];
-                var namevalues = ["display_name", "first_name", "middle_name", "last_name", "maiden_name"];
-                if (improperSapce(getGeniData(person, "name"))) {
-                    var nameupdate = [];
-                    for (var i=0; i < namevalues.length; i++) {
-                        var name = getGeniData(person, namevalues[i]);
-                        if (improperSapce(name)) {
-                            namevaluecheck.push(namevalues[i]);
-                            nameupdate.push(name.replace("  ", " ").trim());
-                        }
-                    }
-                    //Name contains double space
-                    consistencymessage = concat("info") + buildEditLink(person) + " contains a double space in " + getPronoun(getGeniData(person, "gender")) + " name.<sup><a title='" + nameupdate.join("; ") + "' class='fixspace' href='javascript:void(0)' id='space" + getGeniData(person, "id") + "' name='" + namevaluecheck + "'>[fix space]</a></sup>";
-                }
-                if (getGeniData(person, "first_name").contains('&quot;') || getGeniData(person, "first_name").contains('"') || (getGeniData(person, "first_name").contains('(') && getGeniData(person, "first_name").contains(')')) || getGeniData(person, "first_name").split("'").length > 2) {
-                    //Name contains alias
-                    consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in " + getPronoun(getGeniData(person, "gender")) + " first name.";
-                }
-                namevaluecheck = [];
-                for (var i=0; i < namevalues.length; i++) {
-                    var name = getGeniData(person, namevalues[i]);
-                    if (validName(name) && !NameParse.is_camel_case(name) && name !== formatName(name)) {
-                        namevaluecheck.push(namevalues[i]);
-                    }
-                }
-                if (namevaluecheck.length > 0) {
-                    var nameupdate = [];
-                    for (var i=0; i < namevaluecheck.length; i++) {
-                        nameupdate.push(formatName(getGeniData(person, namevaluecheck[i])).replace(/'/g, "&#39;"));
-                    }
-                    //Name contains improper use of uppercase/lowercase
-                    consistencymessage = concat("info") + buildEditLink(person) + " contains incorrect use of uppercase/lowercase in " + getPronoun(getGeniData(person, "gender")) + " name.<sup><a title='" + nameupdate.join("; ") + "' class='fixcase' href='javascript:void(0)' id='case" + getGeniData(person, "id") + "' name='" + namevaluecheck + "'>[fix case]</a></sup>";
-                }
-
-                var fnamesplit = getGeniData(person, "first_name").split(" ");
-                if (fnamesplit.length > 1 && NameParse.is_suffix(fnamesplit[fnamesplit.length-1])) {
-                    //First Name contain suffix
-                    consistencymessage = concat("info") + buildEditLink(person) + " appears to contain a suffix in " + getPronoun(getGeniData(person, "gender")) + " first name.<sup><a title='Move Suffix' class='fixsuffix' href='javascript:void(0)' id='fsuffix" + getGeniData(person, "id") + "'>[fix suffix]</a></sup>";
-                }
-                if (getGeniData(person, "title") !== "") {
-                    var title = getGeniData(person, "title").toLowerCase().replace(/./g, "").replace(/-/g,"");
-                    if (title === "mr" || title === "mrs" || title === "miss" || title === "ms") {
-                        //Salutation in title
-                        consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of salutation in " + getPronoun(getGeniData(person, "gender")) + " title.<sup><a title='Remove salutation' class='clearfield' href='javascript:void(0)' id='cleartitle" + getGeniData(person, "id") + "' name='title'>[fix title]</a></sup>";
-                    } else if (isChild(title) || isPartner(title) || isParent(title) || title === "grandmother" || title === "grandfather") {
-                        //Relationship in title
-                        consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of relationship in " + getPronoun(getGeniData(person, "gender")) + " title.<sup><a title='Remove relationship' class='clearfield' href='javascript:void(0)' id='cleartitle" + getGeniData(person, "id") + "' name='title'>[fix title]</a></sup>";
-                    }
-                }
-
-                if (getGeniData(person, "maiden_name").startsWith("#") || (!isNaN(getGeniData(person, "maiden_name")) && parseInt(getGeniData(person, "maiden_name")) > 5)) {
-                        //Numbering scheme
-                        consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of a numbering scheme in " + getPronoun(getGeniData(person, "gender")) + " birth surname.<sup><a title='Remove numeric' class='clearfield' href='javascript:void(0)' id='clearmaiden_name" + getGeniData(person, "id") + "' name='maiden_name'>[fix name]</a></sup>";
-                }
-                if (getGeniData(person, "suffix") !== "") {
-                    var suffix = getGeniData(person, "suffix").toLowerCase().replace(/./g, "").replace(/-/g,"");
-                    if (suffix === "mr" || suffix === "mrs" || suffix === "miss" || title === "ms") {
-                        //Salutation in suffix
-                        consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of salutation in " + getPronoun(getGeniData(person, "gender")) + " suffix.<sup><a title='Remove salutation' class='clearfield' href='javascript:void(0)' id='clearsuffix" + getGeniData(person, "id") + "' name='suffix'>[fix suffix]</a></sup>";
-                    } else if (suffix.startsWith("#") || (!isNaN(suffix) && suffix > 5)) {
-                        //Numbering scheme
-                        consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of a numbering scheme in " + getPronoun(getGeniData(person, "gender")) + " suffix.<sup><a title='Remove salutation' class='clearfield' href='javascript:void(0)' id='clearsuffix" + getGeniData(person, "id") + "' name='suffix'>[fix suffix]</a></sup>";
-                    } else if (isChild(suffix) || isPartner(suffix) || isParent(suffix) || suffix === "grandmother" || suffix === "grandfather") {
-                        //Relationship in suffix
-                        consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of relationship in " + getPronoun(getGeniData(person, "gender")) + " suffix.<sup><a title='Remove relationship' class='clearfield' href='javascript:void(0)' id='clearsuffix" + getGeniData(person, "id") + "' name='suffix'>[fix suffix]</a></sup>";
-                    }
-                }
+                checkSpace(person);
+                checkAlias(person);
+                checkCase(person);
+                checkSuffixInFirstName(person);
+                checkTitle(person);
+                checkMaidenName(person);
+                checkSuffix(person);
             }
+        }
+    }
+}
+
+function checkSpace(person) {
+    
+    var namevaluecheck = [];
+    var namevalues = ["display_name", "first_name", "middle_name", "last_name", "maiden_name"];
+    if (improperSapce(getGeniData(person, "name"))) {
+        var nameupdate = [];
+        for (var i=0; i < namevalues.length; i++) {
+            var name = getGeniData(person, namevalues[i]);
+            if (improperSapce(name)) {
+                namevaluecheck.push(namevalues[i]);
+                nameupdate.push(name.replace("  ", " ").trim());
+            }
+        }
+        //Name contains double space
+        consistencymessage = concat("info") + buildEditLink(person) + " contains a double space in "
+            + getPronoun(getGeniData(person, "gender")) + " name.<sup><a title='" + nameupdate.join("; ")
+            + "' class='fixspace' href='javascript:void(0)' id='space" + getGeniData(person, "id") + "' name='" + namevaluecheck
+            + "'>[fix space]</a></sup>";
+    }
+}
+
+function checkAlias(person) {
+
+    if (getGeniData(person, "first_name").contains('&quot;') || getGeniData(person, "first_name").contains('"')
+        || (getGeniData(person, "first_name").contains('(') && getGeniData(person, "first_name").contains(')'))
+        || getGeniData(person, "first_name").split("'").length > 2) {
+    
+        //Name contains alias
+        consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in " + getPronoun(getGeniData(person, "gender"))
+            + " first name.";
+    }
+}
+
+function checkCase(person) {    
+    
+    var namevaluecheck = [];
+    var namevalues = ["display_name", "first_name", "middle_name", "last_name", "maiden_name"];
+    for (var i=0; i < namevalues.length; i++) {
+        var name = getGeniData(person, namevalues[i]);
+        if (validName(name) && !NameParse.is_camel_case(name) && name !== formatName(name)) {
+            namevaluecheck.push(namevalues[i]);
+        }
+    }
+    if (namevaluecheck.length > 0) {
+        var nameupdate = [];
+        for (var i=0; i < namevaluecheck.length; i++) {
+            nameupdate.push(formatName(getGeniData(person, namevaluecheck[i])).replace(/'/g, "&#39;"));
+        }
+        //Name contains improper use of uppercase/lowercase
+        consistencymessage = concat("info") + buildEditLink(person) + " contains incorrect use of uppercase/lowercase in "
+            + getPronoun(getGeniData(person, "gender")) + " name.<sup><a title='" + nameupdate.join("; ")
+            + "' class='fixcase' href='javascript:void(0)' id='case" + getGeniData(person, "id") + "' name='" + namevaluecheck
+            + "'>[fix case]</a></sup>";
+    }
+}
+
+function checkSuffixInFirstName(person) {
+    
+    var fnamesplit = getGeniData(person, "first_name").split(" ");
+    if (fnamesplit.length > 1 && NameParse.is_suffix(fnamesplit[fnamesplit.length-1])) {
+        //First Name contain suffix
+        consistencymessage = concat("info") + buildEditLink(person) + " appears to contain a suffix in "
+            + getPronoun(getGeniData(person, "gender"))
+            + " first name.<sup><a title='Move Suffix' class='fixsuffix' href='javascript:void(0)' id='fsuffix" + getGeniData(person, "id")
+            + "'>[fix suffix]</a></sup>";
+    }
+}
+
+function checkTitle(person) {
+    
+    if (getGeniData(person, "title") !== "") {
+        var title = getGeniData(person, "title").toLowerCase().replace(/./g, "").replace(/-/g,"");
+        if (title === "mr" || title === "mrs" || title === "miss" || title === "ms") {
+            //Salutation in title
+            consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of salutation in "
+                + getPronoun(getGeniData(person, "gender"))
+                + " title.<sup><a title='Remove salutation' class='clearfield' href='javascript:void(0)' id='cleartitle"
+                + getGeniData(person, "id") + "' name='title'>[fix title]</a></sup>";
+        } else if (isChild(title) || isPartner(title) || isParent(title) || title === "grandmother" || title === "grandfather") {
+            //Relationship in title
+            consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of relationship in "
+                + getPronoun(getGeniData(person, "gender"))
+                + " title.<sup><a title='Remove relationship' class='clearfield' href='javascript:void(0)' id='cleartitle"
+                + getGeniData(person, "id") + "' name='title'>[fix title]</a></sup>";
+        }
+    }
+}
+
+function checkMaidenName(person) {
+    
+    if (getGeniData(person, "maiden_name").startsWith("#") || (!isNaN(getGeniData(person, "maiden_name"))
+        && parseInt(getGeniData(person, "maiden_name")) > 5)) {
+    
+        //Numbering scheme
+        consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of a numbering scheme in "
+            + getPronoun(getGeniData(person, "gender"))
+            + " birth surname.<sup><a title='Remove numeric' class='clearfield' href='javascript:void(0)' id='clearmaiden_name"
+            + getGeniData(person, "id") + "' name='maiden_name'>[fix name]</a></sup>";
+    }
+}
+
+// Checks that suffix does not contain salutation, improper numbering or relationsship.
+function checkSuffix(person) {
+    
+    if (getGeniData(person, "suffix") !== "") {
+        var suffix = getGeniData(person, "suffix").toLowerCase().replace(/./g, "").replace(/-/g,"");
+        if (suffix === "mr" || suffix === "mrs" || suffix === "miss" || title === "ms") {
+            //Salutation in suffix
+            consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of salutation in "
+                + getPronoun(getGeniData(person, "gender"))
+                + " suffix.<sup><a title='Remove salutation' class='clearfield' href='javascript:void(0)' id='clearsuffix"
+                + getGeniData(person, "id") + "' name='suffix'>[fix suffix]</a></sup>";
+        } else if (suffix.startsWith("#") || (!isNaN(suffix) && suffix > 5)) {
+            //Numbering scheme
+            consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of a numbering scheme in "
+                + getPronoun(getGeniData(person, "gender"))
+                + " suffix.<sup><a title='Remove salutation' class='clearfield' href='javascript:void(0)' id='clearsuffix"
+                + getGeniData(person, "id") + "' name='suffix'>[fix suffix]</a></sup>";
+        } else if (isChild(suffix) || isPartner(suffix) || isParent(suffix) || suffix === "grandmother" || suffix === "grandfather") {
+            //Relationship in suffix
+            consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of relationship in "
+                + getPronoun(getGeniData(person, "gender"))
+                + " suffix.<sup><a title='Remove relationship' class='clearfield' href='javascript:void(0)' id='clearsuffix"
+                + getGeniData(person, "id") + "' name='suffix'>[fix suffix]</a></sup>";
         }
     }
 }

--- a/content.js
+++ b/content.js
@@ -425,6 +425,7 @@ function checkAlias(person) {
 
 function checkCase(person) {    
     
+    // checks for default language names (with fixes)
     var namevaluecheck = [];
     var namevalues = ["display_name", "first_name", "middle_name", "last_name", "maiden_name"];
     for (var i=0; i < namevalues.length; i++) {
@@ -444,6 +445,33 @@ function checkCase(person) {
             + "' class='fixcase' href='javascript:void(0)' id='case" + getGeniData(person, "id") + "' name='" + namevaluecheck
             + "'>[fix case]</a></sup>";
     }
+    // checks for other languages names (without fixes as Geni API does not support it)
+    var names = getGeniData(person, "names");
+    if (names !== "") {
+        var defaultLanguage = true;
+        for (var lang in names) {
+            if (names.hasOwnProperty(lang)) {
+                var nameFound = false;
+                for (var i=0; i < namevalues.length; i++) {
+                    if (names[lang].hasOwnProperty(namevalues[i])) {
+                        nameFound = true;
+                        if (!defaultLanguage) {
+                            // skip first found language with any names as these have been handled above in default language name checks
+                            var name = names[lang][namevalues[i]];
+                            if (validName(name) && !NameParse.is_camel_case(name) && name !== formatName(name)) {
+                                consistencymessage = concat("info") + buildEditLink(person) + " contains incorrect use of uppercase/lowercase in "
+                                    + getPronoun(getGeniData(person, "gender")) + " names (" + lang + ").";
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (nameFound) {
+                    defaultLanguage = false;
+                }
+            }
+        }
+    }    
 }
 
 function checkSuffixInFirstName(person) {

--- a/content.js
+++ b/content.js
@@ -371,7 +371,7 @@ function selfCheck(familyset) {
 }
 
 function checkSpace(person) {
-    
+    // checks for default language names (with fixes)
     var namevaluecheck = [];
     var namevalues = ["display_name", "first_name", "middle_name", "last_name", "maiden_name"];
     if (improperSapce(getGeniData(person, "name"))) {
@@ -389,42 +389,63 @@ function checkSpace(person) {
             + "' class='fixspace' href='javascript:void(0)' id='space" + getGeniData(person, "id") + "' name='" + namevaluecheck
             + "'>[fix space]</a></sup>";
     }
+    // checks for other languages names (without fixes as Geni API does not support it)
+    var names = getGeniData(person, "names");
+    if (names !== "") {
+        var defaultLanguage = true;
+        for (var lang in names) {
+            if (names.hasOwnProperty(lang)) {
+                var nameFound = false;
+                for (var i=0; i < namevalues.length; i++) {
+                    if (names[lang].hasOwnProperty(namevalues[i])) {
+                        nameFound = true;
+                        if (!defaultLanguage) {
+                            // skip first found language with any names as these have been handled above in default language name checks
+                            var name = names[lang][namevalues[i]];
+                            if (improperSapce(name)) {
+                                consistencymessage = concat("info") + buildEditLink(person) + " contains a double space in "
+                                    + getPronoun(getGeniData(person, "gender")) + " names (" + lang + ").";
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (nameFound) {
+                    defaultLanguage = false;
+                }
+            }
+        }
+    }    
 }
 
 function checkAlias(person) {
-
-
     var names = getGeniData(person, "names");
     if (names !== "") {
         for (var lang in names) {
             if (names.hasOwnProperty(lang)) {
                 if (names[lang].hasOwnProperty("first_name")) {
                     var firstName = names[lang]["first_name"];
-                    if (firstName.contains('&quot;') || firstName.contains('"')
-                        || (firstName.contains('(') && firstName.contains(')'))
+                    if (firstName.contains('&quot;') || firstName.contains('"') || (firstName.contains('(') && firstName.contains(')'))
                         || firstName.split("'").length > 2) {
 
-                        //Name contains alias
+                        // Name contains alias
                         consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in "
-                            + getPronoun(getGeniData(person, "gender")) + " first name ("+ lang + ").";
+                            + getPronoun(getGeniData(person, "gender")) + " first name (" + lang + ").";
                     }
                 }
             }
         }
-    } else {
-        if (getGeniData(person, "first_name").contains('&quot;') || getGeniData(person, "first_name").contains('"')
-            || (getGeniData(person, "first_name").contains('(') && getGeniData(person, "first_name").contains(')'))
-            || getGeniData(person, "first_name").split("'").length > 2) {
+    } else if (getGeniData(person, "first_name").contains('&quot;') || getGeniData(person, "first_name").contains('"')
+        || (getGeniData(person, "first_name").contains('(') && getGeniData(person, "first_name").contains(')'))
+        || getGeniData(person, "first_name").split("'").length > 2) {
 
-            //Name contains alias
-            consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in " + getPronoun(getGeniData(person, "gender"))
-                + " first name.";
-        }
+        //Name contains alias
+        consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in " + getPronoun(getGeniData(person, "gender"))
+            + " first name.";
     }
 }
 
 function checkCase(person) {    
-    
     // checks for default language names (with fixes)
     var namevaluecheck = [];
     var namevalues = ["display_name", "first_name", "middle_name", "last_name", "maiden_name"];
@@ -475,7 +496,6 @@ function checkCase(person) {
 }
 
 function checkSuffixInFirstName(person) {
-    
     var fnamesplit = getGeniData(person, "first_name").split(" ");
     if (fnamesplit.length > 1 && NameParse.is_suffix(fnamesplit[fnamesplit.length-1])) {
         //First Name contain suffix
@@ -487,17 +507,16 @@ function checkSuffixInFirstName(person) {
 }
 
 function checkTitle(person) {
-    
     if (getGeniData(person, "title") !== "") {
         var title = getGeniData(person, "title").toLowerCase().replace(/./g, "").replace(/-/g,"");
         if (title === "mr" || title === "mrs" || title === "miss" || title === "ms") {
-            //Salutation in title
+            // Salutation in title
             consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of salutation in "
                 + getPronoun(getGeniData(person, "gender"))
                 + " title.<sup><a title='Remove salutation' class='clearfield' href='javascript:void(0)' id='cleartitle"
                 + getGeniData(person, "id") + "' name='title'>[fix title]</a></sup>";
         } else if (isChild(title) || isPartner(title) || isParent(title) || title === "grandmother" || title === "grandfather") {
-            //Relationship in title
+            // Relationship in title
             consistencymessage = concat("info") + buildEditLink(person) + " contains improper use of relationship in "
                 + getPronoun(getGeniData(person, "gender"))
                 + " title.<sup><a title='Remove relationship' class='clearfield' href='javascript:void(0)' id='cleartitle"
@@ -507,7 +526,6 @@ function checkTitle(person) {
 }
 
 function checkMaidenName(person) {
-    
     if (getGeniData(person, "maiden_name").startsWith("#") || (!isNaN(getGeniData(person, "maiden_name"))
         && parseInt(getGeniData(person, "maiden_name")) > 5)) {
     
@@ -519,9 +537,8 @@ function checkMaidenName(person) {
     }
 }
 
-// Checks that suffix does not contain salutation, improper numbering or relationsship.
+// Checks that suffix does not contain salutation, improper numbering or relationship.
 function checkSuffix(person) {
-    
     if (getGeniData(person, "suffix") !== "") {
         var suffix = getGeniData(person, "suffix").toLowerCase().replace(/./g, "").replace(/-/g,"");
         if (suffix === "mr" || suffix === "mrs" || suffix === "miss" || title === "ms") {

--- a/content.js
+++ b/content.js
@@ -393,13 +393,33 @@ function checkSpace(person) {
 
 function checkAlias(person) {
 
-    if (getGeniData(person, "first_name").contains('&quot;') || getGeniData(person, "first_name").contains('"')
-        || (getGeniData(person, "first_name").contains('(') && getGeniData(person, "first_name").contains(')'))
-        || getGeniData(person, "first_name").split("'").length > 2) {
-    
-        //Name contains alias
-        consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in " + getPronoun(getGeniData(person, "gender"))
-            + " first name.";
+
+    var names = getGeniData(person, "names");
+    if (names !== "") {
+        for (var lang in names) {
+            if (names.hasOwnProperty(lang)) {
+                if (names[lang].hasOwnProperty("first_name")) {
+                    var firstName = names[lang]["first_name"];
+                    if (firstName.contains('&quot;') || firstName.contains('"')
+                        || (firstName.contains('(') && firstName.contains(')'))
+                        || firstName.split("'").length > 2) {
+
+                        //Name contains alias
+                        consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in "
+                            + getPronoun(getGeniData(person, "gender")) + " first name ("+ lang + ").";
+                    }
+                }
+            }
+        }
+    } else {
+        if (getGeniData(person, "first_name").contains('&quot;') || getGeniData(person, "first_name").contains('"')
+            || (getGeniData(person, "first_name").contains('(') && getGeniData(person, "first_name").contains(')'))
+            || getGeniData(person, "first_name").split("'").length > 2) {
+
+            //Name contains alias
+            consistencymessage = concat("info") + buildEditLink(person) + " contains an alias in " + getPronoun(getGeniData(person, "gender"))
+                + " first name.";
+        }
     }
 }
 

--- a/content.js
+++ b/content.js
@@ -53,7 +53,7 @@ function queryGeni() {
         dconflict = ",data_conflict";
     }
     familystatus.push(1);
-    var args = "fields=id,guid,name,title,first_name,middle_name,last_name,maiden_name,suffix,display_name,gender,deleted,birth,baptism,death,burial,is_alive,marriage,divorce,public" + dconflict;
+    var args = "fields=id,guid,name,title,first_name,middle_name,last_name,maiden_name,suffix,display_name,names,gender,deleted,birth,baptism,death,burial,is_alive,marriage,divorce,public" + dconflict;
     var url = "https://www.geni.com/api/" + focusid + "/immediate-family?" + args;
     chrome.runtime.sendMessage({
         method: "GET",


### PR DESCRIPTION
Added space, alias and uppercase/lowercase checks for additional languages. Quick fixes work only for default language, it seems API support is missing for this. Checks have been refactored to their own functions as the original selfCheck function was getting a bit long and more checks are planned.

Tested mostly in Chrome, but quickly also in Opera & Firefox - except for space checks - Geni removes spaces automatically and I was not able to find existing samples.