### PR TITLE
Fix Ancestry family-fetch hang and migrate to current person-data page structure

### DIFF
--- a/collections/ancestrynew.js
+++ b/collections/ancestrynew.js
@@ -122,9 +122,20 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
         try {
             personFacts = JSON.parse(htmlstring.substring(pfStart + 14, pfEnd + 1));
         } catch (err) {
+            console.warn("Ancestry: failed to parse researchData JSON", err);
             personFacts = {};
         }
+    } else {
+        console.warn("Ancestry: researchData block not found on page");
     }
+    personFacts.PersonFacts = personFacts.PersonFacts || [];
+    personFacts.ResearchFamily = personFacts.ResearchFamily || {};
+    personFacts.ResearchFamily.Children = personFacts.ResearchFamily.Children || [];
+    personFacts.ResearchFamily.HalfSiblings = personFacts.ResearchFamily.HalfSiblings || [];
+    personFacts.ResearchFamily.Siblings = personFacts.ResearchFamily.Siblings || [];
+    personFacts.ResearchFamily.Fathers = personFacts.ResearchFamily.Fathers || [];
+    personFacts.ResearchFamily.Mothers = personFacts.ResearchFamily.Mothers || [];
+    personFacts.ResearchFamily.Spouses = personFacts.ResearchFamily.Spouses || [];
 
     // useful for debugging Ancestry calls
     // console.log("Ancestry new - entering with PersonCard: {} personFacts: {} familymembers: {} relation: {}", personCard, personFacts, familymembers, relation);

--- a/collections/ancestrynew.js
+++ b/collections/ancestrynew.js
@@ -79,58 +79,156 @@ registerCollection({
 
 var ancestrymrglist = [];
 
+function resolveAncestryUrl(url) {
+    if (exists(url) && url.startsWith("/")) {
+        return "https://www.ancestry.com" + url;
+    }
+    return url;
+}
+
+// Ancestry (as of 2026) embeds all person data as a single JSON blob in
+// <script id="person-data" type="application/json">. Older trees/pages may
+// still be served with the legacy inline `var PersonCard = {...}` script
+// plus a separate `researchData = {...}` blob, so fall back to that if the
+// new block isn't found.
+function extractNewPersonData(htmlstring) {
+    var marker = '<script id="person-data" type="application/json">';
+    var start = htmlstring.indexOf(marker);
+    if (start === -1) {
+        return null;
+    }
+    start += marker.length;
+    var end = htmlstring.indexOf("</script>", start);
+    if (end === -1) {
+        return null;
+    }
+    var pageData;
+    try {
+        pageData = JSON.parse(htmlstring.substring(start, end));
+    } catch (err) {
+        console.warn("Ancestry: failed to parse #person-data JSON", err);
+        return null;
+    }
+    var personCard = (pageData.person && pageData.person.PersonCard) || {};
+    var personResearch = (pageData.person && pageData.person.PersonResearch) || {};
+    var family = personResearch.PersonFamily || {};
+    return {
+        name: exists(personCard.FullName) ? personCard.FullName.trim() : "",
+        daterange: exists(personCard.LifeRange) ? personCard.LifeRange.replace("&ndash;", " - ") : "",
+        isLiving: !!personCard.IsLiving,
+        imageUrl: resolveAncestryUrl(personCard.PrimaryImageUrl) || "",
+        genderHint: "",
+        personId: pageData.personId,
+        facts: personResearch.PersonFacts || [],
+        family: {
+            Children: family.Children || [],
+            HalfSiblings: family.HalfSiblings || [],
+            Siblings: family.Siblings || [],
+            Fathers: family.Fathers || [],
+            Mothers: family.Mothers || [],
+            Spouses: family.Spouses || []
+        }
+    };
+}
+
+async function extractLegacyPersonData(htmlstring) {
+    var personCard = {};
+    try {
+        var foundScript = $("script:contains('var PersonCard')", htmlstring).text();
+        if (foundScript) {
+            foundScript = foundScript.substring(0, foundScript.indexOf("};") + 2) + "PersonCard;";
+            personCard = await chrome.runtime.sendMessage({
+                action: "eval",
+                variable: foundScript
+            }) || {};
+        }
+    } catch (err) {
+        personCard = {};
+    }
+
+    var facts = [];
+    var family = {};
+    var pfStart = htmlstring.indexOf("researchData = ");
+    if (pfStart !== -1) {
+        var pfEnd = htmlstring.indexOf("};", pfStart);
+        if (pfEnd !== -1) {
+            try {
+                var researchData = JSON.parse(htmlstring.substring(pfStart + 14, pfEnd + 1));
+                facts = researchData.PersonFacts || [];
+                family = researchData.ResearchFamily || {};
+            } catch (err) {
+                console.warn("Ancestry: failed to parse legacy researchData JSON", err);
+            }
+        }
+    }
+
+    var imageUrl = "";
+    if (exists(personCard.photo)) {
+        var imgSrc = $("img", personCard.photo).attr("src");
+        if (exists(imgSrc)) {
+            imageUrl = imgSrc;
+        }
+    }
+
+    return {
+        name: exists(personCard.name) ? personCard.name.trim() : "",
+        daterange: exists(personCard.lifeYearRange) ? personCard.lifeYearRange.replace("&ndash;", " - ") : "",
+        isLiving: !!personCard.isLiving,
+        imageUrl: imageUrl,
+        genderHint: exists(personCard.gender) ? personCard.gender : "",
+        personId: personCard.personId,
+        facts: facts,
+        family: {
+            Children: family.Children || [],
+            HalfSiblings: family.HalfSiblings || [],
+            Siblings: family.Siblings || [],
+            Fathers: family.Fathers || [],
+            Mothers: family.Mothers || [],
+            Spouses: family.Spouses || []
+        }
+    };
+}
+
+async function extractAncestryPersonData(htmlstring) {
+    var data = extractNewPersonData(htmlstring);
+    if (data) {
+        return data;
+    }
+    console.warn("Ancestry: #person-data block not found, falling back to legacy page format");
+    return await extractLegacyPersonData(htmlstring);
+}
+
 async function parseAncestryNew(htmlstring, familymembers, relation) {
     relation = relation || "";
     if (!exists(htmlstring)) {
         return "";
     }
 
-    // Ancestry embeds all person data as JSON in a single <script id="person-data"> block
-    let pageData = {};
-    try {
-        var personDataText = $("script#person-data", htmlstring).text();
-        pageData = JSON.parse(personDataText);
-    } catch (err) {
-        console.warn("Ancestry: failed to parse #person-data JSON", err);
-        pageData = {};
-    }
+    var data = await extractAncestryPersonData(htmlstring);
+    var focusPersonId = data.personId;
 
-    let personCard = (pageData.person && pageData.person.PersonCard) || {};
-    let personResearch = (pageData.person && pageData.person.PersonResearch) || {};
-    let focusPersonId = pageData.personId;
-
-    let personFacts = {};
-    personFacts.PersonFacts = personResearch.PersonFacts || [];
-    personFacts.ResearchFamily = personResearch.PersonFamily || {};
-    personFacts.ResearchFamily.Children = personFacts.ResearchFamily.Children || [];
-    personFacts.ResearchFamily.HalfSiblings = personFacts.ResearchFamily.HalfSiblings || [];
-    personFacts.ResearchFamily.Siblings = personFacts.ResearchFamily.Siblings || [];
-    personFacts.ResearchFamily.Fathers = personFacts.ResearchFamily.Fathers || [];
-    personFacts.ResearchFamily.Mothers = personFacts.ResearchFamily.Mothers || [];
-    personFacts.ResearchFamily.Spouses = personFacts.ResearchFamily.Spouses || [];
-
-    let focusperson = exists(personCard.FullName) ? personCard.FullName.trim() : "";
-    let focusdaterange = exists(personCard.LifeRange) ? personCard.LifeRange.replace("&ndash;", " - ") : "";
+    let focusperson = data.name;
+    let focusdaterange = data.daterange;
 
     $("#readstatus").html(escapeHtml(focusperson));
     var profiledata = {};
-    var genderval = getAncestryGender(personFacts);
+    var genderval = getAncestryGender(data.facts, data.genderHint);
     var burialdtflag = false;
     var buriallcflag = false;
     var deathdtflag = false;
     var aboutdata = "";
 
     profiledata["gender"] = genderval;
-    if (personCard.IsLiving) {
-        profiledata["alive"] = personCard.IsLiving;
+    if (data.isLiving) {
+        profiledata["alive"] = data.isLiving;
     }
 
     profiledata["name"] = focusperson;
     profiledata["status"] = relation.title;
 
     // Loop through important life events
-    for(var i = 0; i < personFacts.PersonFacts.length; i++) {
-        const fact = personFacts.PersonFacts[i];
+    for(var i = 0; i < data.facts.length; i++) {
+        const fact = data.facts[i];
         // we only want to examine FactType 0 which apply to this person
         if (fact.FactType != 0) continue;
         switch(fact.TypeString) {
@@ -170,11 +268,8 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
         }
     }
 
-    if (exists(personCard.PrimaryImageUrl)) {
-        var image = personCard.PrimaryImageUrl;
-        if (image.startsWith("/")) {
-            image = "https://www.ancestry.com" + image;
-        }
+    if (data.imageUrl !== "") {
+        var image = data.imageUrl;
         profiledata["thumb"] = image.replace("&maxHeight=280", "&maxWidth=152");
         profiledata["image"] = image.replace("&maxHeight=280", "");
     }
@@ -189,12 +284,12 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
     }
 
     // ---------------------- Family Data --------------------
-    for(var x = 0; x < personFacts.ResearchFamily.Children.length; x++) {
-        var childgroup = personFacts.ResearchFamily.Children[x];
+    for(var x = 0; x < data.family.Children.length; x++) {
+        var childgroup = data.family.Children[x];
         if (!exists(childgroup)) continue;
         var children = Array.isArray(childgroup) ? childgroup : [childgroup];
         if (!Array.isArray(childgroup)) {
-            console.warn("Ancestry: ResearchFamily.Children entry was not an array, wrapping it", childgroup);
+            console.warn("Ancestry: Children entry was not an array, wrapping it", childgroup);
         }
         for(var i = 0; i < children.length; i++) {
             var child = children[i]
@@ -203,20 +298,20 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
             }
         }
     }
-    for(var i = 0; i < personFacts.ResearchFamily.HalfSiblings.length; i++) {
-        var halfsibling = personFacts.ResearchFamily.HalfSiblings[i];
+    for(var i = 0; i < data.family.HalfSiblings.length; i++) {
+        var halfsibling = data.family.HalfSiblings[i];
         if (familymembers && exists(halfsibling.ClickUrl)) {
             await getAncestryNewTreeFamily(famid++, halfsibling.Id, halfsibling.FullName.trim(), "halfsibling", halfsibling.ClickUrl);
         }
     }
-    for(var i = 0; i < personFacts.ResearchFamily.Siblings.length; i++) {
-        var sibling = personFacts.ResearchFamily.Siblings[i];
+    for(var i = 0; i < data.family.Siblings.length; i++) {
+        var sibling = data.family.Siblings[i];
         if (familymembers && exists(sibling.ClickUrl)) {
             await getAncestryNewTreeFamily(famid++, sibling.Id, sibling.FullName.trim(), "sibling", sibling.ClickUrl);
         }
     }
-    for(var i = 0; i < personFacts.ResearchFamily.Fathers.length; i++) {
-        var father = personFacts.ResearchFamily.Fathers[i];
+    for(var i = 0; i < data.family.Fathers.length; i++) {
+        var father = data.family.Fathers[i];
         if (familymembers) {
             if (exists(father.ClickUrl)) {
                 await getAncestryNewTreeFamily(famid++, father.Id, father.FullName.trim(), "father", father.ClickUrl);
@@ -230,8 +325,8 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
             }
         }
     }
-    for(var i = 0; i < personFacts.ResearchFamily.Mothers.length; i++) {
-        var mother = personFacts.ResearchFamily.Mothers[i];
+    for(var i = 0; i < data.family.Mothers.length; i++) {
+        var mother = data.family.Mothers[i];
         if (familymembers) {
             if (exists(mother.ClickUrl)) {
                 await getAncestryNewTreeFamily(famid++, mother.Id, mother.FullName.trim(), "mother", mother.ClickUrl);
@@ -245,8 +340,8 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
             }
         }
     }
-    for(var i = 0; i < personFacts.ResearchFamily.Spouses.length; i++) {
-        var spouse = personFacts.ResearchFamily.Spouses[i];
+    for(var i = 0; i < data.family.Spouses.length; i++) {
+        var spouse = data.family.Spouses[i];
         if (spouse.FullName.trim().toLowerCase() == "no spouse") continue;
         if (familymembers && exists(spouse.ClickUrl)) {
             myhspouse.push(spouse.Id);
@@ -358,16 +453,19 @@ async function getAncestryNewTreeFamily(famid, itemid, name, title, url) {
     });
 }
 
-function getAncestryGender(personFacts) {
+function getAncestryGender(facts, genderHint) {
     let genderval = 'unknown';
-    if (personFacts && Array.isArray(personFacts.PersonFacts)) {
-        for (var i = 0; i < personFacts.PersonFacts.length; i++) {
-            var fact = personFacts.PersonFacts[i];
+    if (Array.isArray(facts)) {
+        for (var i = 0; i < facts.length; i++) {
+            var fact = facts[i];
             if (fact.TypeString === 'Gender' && exists(fact.Value) && (isFemale(fact.Value) || isMale(fact.Value))) {
                 genderval = fact.Value.toLowerCase();
                 break;
             }
         }
+    }
+    if (genderval === 'unknown' && exists(genderHint) && (isFemale(genderHint) || isMale(genderHint))) {
+        genderval = genderHint.toLowerCase();
     }
     if (genderval === 'f') {
         genderval = 'female';

--- a/collections/ancestrynew.js
+++ b/collections/ancestrynew.js
@@ -79,57 +79,29 @@ registerCollection({
 
 var ancestrymrglist = [];
 
-async function readPersonCard(htmlstring) {
-    var foundScript = $("script:contains('var PersonCard')", htmlstring).text();
-    
-    return new Promise((resolve, reject) => {
-        // TODO assign the return of this to the PersonCard object
-        if (foundScript) {
-            // truncate the end
-            foundScript = foundScript.substring(0, foundScript.indexOf("};") + 2) + "PersonCard;";
-            chrome.runtime.sendMessage({
-                action: "eval",
-                variable: foundScript
-            }).then((resp) => {
-                // TODO - need to figure out how to use this
-                resolve(resp);
-            });
-        } else {
-            reject("PersonCard not found");
-        }
-    });
-
-}
-
 async function parseAncestryNew(htmlstring, familymembers, relation) {
     relation = relation || "";
     if (!exists(htmlstring)) {
         return "";
     }
-    // TODO - figure out where the parsing issues are
-    let personCard = {};
+
+    // Ancestry embeds all person data as JSON in a single <script id="person-data"> block
+    let pageData = {};
     try {
-        personCard = await readPersonCard(htmlstring);
+        var personDataText = $("script#person-data", htmlstring).text();
+        pageData = JSON.parse(personDataText);
     } catch (err) {
-        personCard = {};
+        console.warn("Ancestry: failed to parse #person-data JSON", err);
+        pageData = {};
     }
 
-    // get personFacts
-    const pfStart = htmlstring.indexOf("researchData = ");
-    const pfEnd = htmlstring.indexOf("};", pfStart);
+    let personCard = (pageData.person && pageData.person.PersonCard) || {};
+    let personResearch = (pageData.person && pageData.person.PersonResearch) || {};
+    let focusPersonId = pageData.personId;
+
     let personFacts = {};
-    if (pfStart !== -1 && pfEnd !== -1) {
-        try {
-            personFacts = JSON.parse(htmlstring.substring(pfStart + 14, pfEnd + 1));
-        } catch (err) {
-            console.warn("Ancestry: failed to parse researchData JSON", err);
-            personFacts = {};
-        }
-    } else {
-        console.warn("Ancestry: researchData block not found on page");
-    }
-    personFacts.PersonFacts = personFacts.PersonFacts || [];
-    personFacts.ResearchFamily = personFacts.ResearchFamily || {};
+    personFacts.PersonFacts = personResearch.PersonFacts || [];
+    personFacts.ResearchFamily = personResearch.PersonFamily || {};
     personFacts.ResearchFamily.Children = personFacts.ResearchFamily.Children || [];
     personFacts.ResearchFamily.HalfSiblings = personFacts.ResearchFamily.HalfSiblings || [];
     personFacts.ResearchFamily.Siblings = personFacts.ResearchFamily.Siblings || [];
@@ -137,34 +109,20 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
     personFacts.ResearchFamily.Mothers = personFacts.ResearchFamily.Mothers || [];
     personFacts.ResearchFamily.Spouses = personFacts.ResearchFamily.Spouses || [];
 
-    // useful for debugging Ancestry calls
-    // console.log("Ancestry new - entering with PersonCard: {} personFacts: {} familymembers: {} relation: {}", personCard, personFacts, familymembers, relation);
-    let focusperson = "";
-    if (exists(personCard.name)) {
-        focusperson = personCard.name.trim();
-    } else if (personFacts.PersonInfo && personFacts.PersonInfo.FullName) {
-        focusperson = personFacts.PersonInfo.FullName.trim();
-    }
+    let focusperson = exists(personCard.FullName) ? personCard.FullName.trim() : "";
+    let focusdaterange = exists(personCard.LifeRange) ? personCard.LifeRange.replace("&ndash;", " - ") : "";
 
-    let focusdaterange = "";
-    if (exists(personCard.lifeYearRange)) {
-        focusdaterange = personCard.lifeYearRange.replace("&ndash;", " - ");
-    } else if (personFacts.PersonInfo && personFacts.PersonInfo.LifeSpan) {
-        focusdaterange = personFacts.PersonInfo.LifeSpan.replace("&ndash;", " - ");
-    }
     $("#readstatus").html(escapeHtml(focusperson));
     var profiledata = {};
-    var genderval = getAncestryGender(personCard, personFacts);
+    var genderval = getAncestryGender(personFacts);
     var burialdtflag = false;
     var buriallcflag = false;
     var deathdtflag = false;
     var aboutdata = "";
-    
-    if (genderval !== "unknown") {
-        profiledata["gender"] = genderval;
-    }
-    if (personCard.isLiving) {
-        profiledata["alive"] = personCard.isLiving;
+
+    profiledata["gender"] = genderval;
+    if (personCard.IsLiving) {
+        profiledata["alive"] = personCard.IsLiving;
     }
 
     profiledata["name"] = focusperson;
@@ -212,12 +170,13 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
         }
     }
 
-    if (exists(personCard.photo)) {
-        var image = $("img", personCard.photo).attr("src");
-        if (exists(image)) {
-            profiledata["thumb"] = image.replace("&maxHeight=280", "&maxWidth=152");
-            profiledata["image"] = image.replace("&maxHeight=280", "");
+    if (exists(personCard.PrimaryImageUrl)) {
+        var image = personCard.PrimaryImageUrl;
+        if (image.startsWith("/")) {
+            image = "https://www.ancestry.com" + image;
         }
+        profiledata["thumb"] = image.replace("&maxHeight=280", "&maxWidth=152");
+        profiledata["image"] = image.replace("&maxHeight=280", "");
     }
 
     if (relation === "") {
@@ -263,8 +222,8 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
                 await getAncestryNewTreeFamily(famid++, father.Id, father.FullName.trim(), "father", father.ClickUrl);
             }
         } else if (exists(relation.title)) {
-            if (isChild(relation.tite)) {
-                if (personCard.personId !== father.Id) {
+            if (isChild(relation.title)) {
+                if (String(focusPersonId) !== String(father.Id)) {
                     childlist[relation.proid] = $.inArray(father.Id, unionurls);
                     profiledata["parent_id"] = $.inArray(father.Id, unionurls);
                 }
@@ -278,8 +237,8 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
                 await getAncestryNewTreeFamily(famid++, mother.Id, mother.FullName.trim(), "mother", mother.ClickUrl);
             }
         } else if (exists(relation.title)) {
-            if (isChild(relation.tite)) {
-                if (personCard.personId !== mother.Id) {
+            if (isChild(relation.title)) {
+                if (String(focusPersonId) !== String(mother.Id)) {
                     childlist[relation.proid] = $.inArray(mother.Id, unionurls);
                     profiledata["parent_id"] = $.inArray(mother.Id, unionurls);
                 }
@@ -338,8 +297,10 @@ function setFactData(fact) {
 
 
 async function getAncestryNewTreeFamily(famid, itemid, name, title, url) {
-    
-    return new Promise((resolve, reject) => {  
+    if (url.startsWith("/")) {
+        url = "https://www.ancestry.com" + url;
+    }
+    return new Promise((resolve, reject) => {
         var gendersv = "unknown";
         var halfsibling = false;
         if (title === "halfsibling") {
@@ -397,25 +358,21 @@ async function getAncestryNewTreeFamily(famid, itemid, name, title, url) {
     });
 }
 
-function getAncestryGender(personCard, personFacts) {
+function getAncestryGender(personFacts) {
     let genderval = 'unknown';
-    if (personCard && (isFemale(personCard.gender) || isMale(personCard.gender))) {
-        genderval = personCard.gender.toLowerCase();
-        if (genderval === 'f') {
-            genderval = 'female';
-        } else if (genderval === 'm') {
-            genderval = 'male';
+    if (personFacts && Array.isArray(personFacts.PersonFacts)) {
+        for (var i = 0; i < personFacts.PersonFacts.length; i++) {
+            var fact = personFacts.PersonFacts[i];
+            if (fact.TypeString === 'Gender' && exists(fact.Value) && (isFemale(fact.Value) || isMale(fact.Value))) {
+                genderval = fact.Value.toLowerCase();
+                break;
+            }
         }
-    } else if (personFacts && personFacts.PersonInfo && personFacts.PersonInfo.Gender) {
-        genderval = personFacts.PersonInfo.Gender.toLowerCase();
-        if (genderval === 'f') {
-            genderval = 'female';
-        } else if (genderval === 'm') {
-            genderval = 'male';
-        }
-        if (!isFemale(genderval) && !isMale(genderval)) {
-            genderval = 'unknown';
-        }
+    }
+    if (genderval === 'f') {
+        genderval = 'female';
+    } else if (genderval === 'm') {
+        genderval = 'male';
     }
     return genderval;
 }

--- a/collections/ancestrynew.js
+++ b/collections/ancestrynew.js
@@ -231,7 +231,12 @@ async function parseAncestryNew(htmlstring, familymembers, relation) {
 
     // ---------------------- Family Data --------------------
     for(var x = 0; x < personFacts.ResearchFamily.Children.length; x++) {
-        var children = personFacts.ResearchFamily.Children[x];
+        var childgroup = personFacts.ResearchFamily.Children[x];
+        if (!exists(childgroup)) continue;
+        var children = Array.isArray(childgroup) ? childgroup : [childgroup];
+        if (!Array.isArray(childgroup)) {
+            console.warn("Ancestry: ResearchFamily.Children entry was not an array, wrapping it", childgroup);
+        }
         for(var i = 0; i < children.length; i++) {
             var child = children[i]
             if (familymembers && exists (child.ClickUrl)) {

--- a/collections/ancestrynew.js
+++ b/collections/ancestrynew.js
@@ -351,25 +351,32 @@ async function getAncestryNewTreeFamily(famid, itemid, name, title, url) {
             url: url,
             variable: subdata
         }, async function(response) {
-            await response;
-            var arg = response.variable;
-            var person = await parseAncestryNew(response.source, false, {
-                "title": arg.title,
-                "proid": arg.profile_id,
-                "itemId": arg.itemId
-            });
-            if (person === "") {
+            try {
+                await response;
+                var arg = response.variable;
+                var person = await parseAncestryNew(response.source, false, {
+                    "title": arg.title,
+                    "proid": arg.profile_id,
+                    "itemId": arg.itemId
+                });
+                if (person === "") {
+                    familystatus.pop();
+                    resolve(false);
+                    return;
+                }
+                if (arg.halfsibling) {
+                    person["halfsibling"] = true;
+                }
+                person = updateInfoData(person, arg);
+                databyid[arg.profile_id] = person;
+                alldata["family"][arg.title].push(person);
                 familystatus.pop();
-                return;
+                resolve(true);
+            } catch (err) {
+                console.error("getAncestryNewTreeFamily failed for", url, err);
+                familystatus.pop();
+                resolve(false);
             }
-            if (arg.halfsibling) {
-                person["halfsibling"] = true;
-            }
-            person = updateInfoData(person, arg);
-            databyid[arg.profile_id] = person;
-            alldata["family"][arg.title].push(person);
-            familystatus.pop();
-            resolve(true);
         });
     });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "__MSG_appShortName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "4.13.1.0",
+    "version": "4.13.1.1",
     "icons": { "16": "images/icon16.png",
         "48": "images/icon48.png",
         "128": "images/icon128.png" },


### PR DESCRIPTION
## Summary
- Fixes "Reading Family Data..." hanging forever when setting a Geni destination from an Ancestry profile
- Ancestry has moved to a new page structure: person data now ships as a single JSON blob in `<script id="person-data" type="application/json">`, replacing the old inline `var PersonCard = {...}` script + separate `researchData = {...}` blob. The parser was silently failing against this on every live page.
- `collections/ancestrynew.js` now extracts from the current format first and falls back to the legacy format if the new block isn't found, so older-format pages (if any are still served) keep working.

## What was actually broken (found via live debugging on a real profile)
1. `getAncestryNewTreeFamily`'s wrapping promise was never resolved when a family member's page returned no usable content (e.g. private/living relatives) - every `await getAncestryNewTreeFamily(...)` in the Children/Siblings/Fathers/Mothers/Spouses loops would then block forever.
2. Unguarded `personFacts.PersonFacts.length` / `ResearchFamily.*.length` access threw when `researchData` couldn't be parsed, aborting the whole parse uncaught.
3. `ResearchFamily.Children` entries weren't guaranteed to be arrays; iterating `.length` on a bad entry threw the same way.
4. Root cause of all the above stopping short: `researchData`/`var PersonCard` no longer exist on current Ancestry pages - replaced by `#person-data`. Extraction now reads that block directly (string-sliced, not jQuery-parsed, which was silently returning empty/truncated content).
5. Small bugs fixed along the way: `relation.tite` typo (should be `relation.title`, made a parent-id-linking branch dead code), gender now sourced from the explicit `"Gender"` fact entry instead of a field path that no longer exists, and `profiledata["gender"]` is now always set (including `"unknown"`) to match every other collection parser's convention - `buildform.js`'s relationship-based gender-recovery fallback depends on that literal string being present.
6. `ClickUrl`/`PrimaryImageUrl` values in the new JSON are relative paths; qualified against `ancestry.com` before fetching, since the background service worker has no page origin to resolve against.

Version bumped to 4.13.1.1, tagged `v4.13.1.1`.

## Test plan
- [x] Manually reproduced the hang on a live Ancestry profile with a private/living relative, confirmed fix via an unpacked "test" build alongside the production extension
- [x] Verified `Set Destination` now completes and correctly populates name, dates, gender, and family members on a real profile
- [x] Would appreciate a second pass testing against a few different profile types (multiple spouses, no children, etc.) before this goes out to the Chrome Web Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)