### PR TITLE
Add Forest Density Calculator and Path to User links to top menu

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -201,6 +201,12 @@
     "History_Search": {
         "message": "History Search"
     },
+    "Forest_Density_Calculator": {
+        "message": "Forest Density Calculator"
+    },
+    "Path_To_User": {
+        "message": "Path to User"
+    },
     "Configuration": {
         "message": "Configuration"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "__MSG_appShortName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "4.13.1.2",
+    "version": "4.13.2.0",
     "icons": { "16": "images/icon16.png",
         "48": "images/icon48.png",
         "128": "images/icon128.png" },

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "__MSG_appShortName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "4.13.1.1",
+    "version": "4.13.1.2",
     "icons": { "16": "images/icon16.png",
         "48": "images/icon48.png",
         "128": "images/icon128.png" },

--- a/popup.html
+++ b/popup.html
@@ -24,7 +24,11 @@
                     href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
                     id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
-                Search</a></strong>
+                Search</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                    href="http://gfdc.wnx.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Forest
+                Density Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                    href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path
+                to User</a></strong>
             </span>
             <span id="optionbutton" style="float: right; padding-right: 2px; padding-left:5px; cursor: pointer;">
                <strong id="configtext" data-i18n="Configuration">Configuration</strong><img src="/images/admin.png" alt="Administration" style="width: 16px; vertical-align: middle; padding-left: 5px;">

--- a/popup.html
+++ b/popup.html
@@ -17,20 +17,22 @@
 <div id="backlinks" style="text-align:center; margin: 0 -8px;  padding: 3px 8px 0; border-top: solid 1px #ddd;">
     <div id="options"
          style="margin: -2px -8px 2px -8px; padding: 2px 8px; background-color: #fff; box-shadow: 0 1px 0 #fff; border-bottom: solid 1px #ddd;">
-        <div style="background-color:#e5ebf0; font-size: 82%; vertical-align: middle; margin: -2px -8px; padding: 2px 10px 4px; text-align: left;">
-            <div style="margin-right: 8px; padding-left: 5px;"><strong><a
-                    href="https://historylinktools.herokuapp.com/graph?color=gender" style="color:#000;" target="_blank" id="graphurl" data-i18n="Ancestor_Graph">Ancestor
-                Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
-                    href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
-                    id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
-                    href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
-                Search</a></strong></div>
-            <div style="margin-right: 8px; padding-left: 5px;"><strong><a
-                    href="http://gfdc.wnx.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Forest
-                Density Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
-                    href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path
-                to User</a></strong></div>
-            <span id="optionbutton" style="float: right; padding-right: 2px; padding-left:5px; cursor: pointer;">
+        <div style="background-color:#e5ebf0; font-size: 82%; vertical-align: middle; margin: -2px -8px; padding: 2px 10px 4px; text-align: left; display: flex; justify-content: space-between; align-items: flex-start;">
+            <div>
+                <div style="margin-right: 8px; padding-left: 5px;"><strong><a
+                        href="https://historylinktools.herokuapp.com/graph?color=gender" style="color:#000;" target="_blank" id="graphurl" data-i18n="Ancestor_Graph">Ancestor
+                    Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
+                        id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
+                    Search</a></strong></div>
+                <div style="margin-right: 8px; padding-left: 5px;"><strong><a
+                        href="http://gfdc.wnx.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Forest
+                    Density Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path
+                    to User</a></strong></div>
+            </div>
+            <span id="optionbutton" style="flex-shrink: 0; padding-right: 2px; padding-left:5px; cursor: pointer;">
                <strong id="configtext" data-i18n="Configuration">Configuration</strong><img src="/images/admin.png" alt="Administration" style="width: 16px; vertical-align: middle; padding-left: 5px;">
             </span>
         </div>

--- a/popup.html
+++ b/popup.html
@@ -24,7 +24,7 @@
                     href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
                     id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
-                Search</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                Search</a><br> <a
                     href="http://gfdc.wnx.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Forest
                 Density Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path

--- a/popup.html
+++ b/popup.html
@@ -18,18 +18,18 @@
     <div id="options"
          style="margin: -2px -8px 2px -8px; padding: 2px 8px; background-color: #fff; box-shadow: 0 1px 0 #fff; border-bottom: solid 1px #ddd;">
         <div style="background-color:#e5ebf0; font-size: 82%; vertical-align: middle; margin: -2px -8px; padding: 2px 10px 4px; text-align: left;">
-            <span style="margin-right: 8px; padding-left: 5px;"><strong><a
+            <div style="margin-right: 8px; padding-left: 5px;"><strong><a
                     href="https://historylinktools.herokuapp.com/graph?color=gender" style="color:#000;" target="_blank" id="graphurl" data-i18n="Ancestor_Graph">Ancestor
                 Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
                     id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
-                Search</a><br><a
+                Search</a></strong></div>
+            <div style="margin-right: 8px; padding-left: 5px;"><strong><a
                     href="http://gfdc.wnx.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Forest
                 Density Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path
-                to User</a></strong>
-            </span>
+                to User</a></strong></div>
             <span id="optionbutton" style="float: right; padding-right: 2px; padding-left:5px; cursor: pointer;">
                <strong id="configtext" data-i18n="Configuration">Configuration</strong><img src="/images/admin.png" alt="Administration" style="width: 16px; vertical-align: middle; padding-left: 5px;">
             </span>

--- a/popup.html
+++ b/popup.html
@@ -24,7 +24,7 @@
                     href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
                     id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
-                Search</a><br> <a
+                Search</a><br><a
                     href="http://gfdc.wnx.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Forest
                 Density Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                     href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path


### PR DESCRIPTION
## Summary
- Adds two new links to the top menu bar in the popup, alongside Ancestor Graph / Descendant Graph / History Search:
  - **Forest Density Calculator** — http://gfdc.wnx.com/
  - **Path to User** — https://path-to-user.herokuapp.com/
- With 5 links, a single bulleted row got too long, so the menu now wraps to two rows: `Ancestor Graph • Descendant Graph • History Search` on the first line, `Forest Density Calculator • Path to User` on the second.
- Fixed a layout regression this caused along the way: the "Configuration" button (top-right gear/settings toggle) was floated, and floats can't sit beside a full-width block - splitting the menu into two rows pushed it down below both rows. Switched that section to flexbox so it stays pinned at the top regardless of how many menu rows there are.

Note: `http://gfdc.wnx.com/` is plain HTTP, not HTTPS - flagging in case that's not intentional on the destination site's end.

Version bumped to `4.13.1.2`, tagged `v4.13.1.2`. This is independent of PR #174 (the Ancestry parsing fix) - built off current master, not off that branch, so it can merge in either order.

## Test plan
- [x] Verified both new links open correctly in a new tab
- [x] Verified menu wraps to two lines and both rows align at the same left edge
- [x] Verified "Configuration" stays pinned top-right regardless of menu row count

🤖 Generated with [Claude Code](https://claude.com/claude-code)