### PR TITLE
WikiTree: fix name/date field leaks found while testing #165

### DIFF
--- a/collections/wikitree.js
+++ b/collections/wikitree.js
@@ -18,10 +18,12 @@ registerCollection({
     },
     "loadPage": function(request) {
         var parsed = $(request.source.replace(/<img[^>]*>/ig, ""));
+        parsed.find(".VITALS .EDIT, .VITALS .BLANK").remove();
         var personinfo = parsed.find(".VITALS");
         var focusperson = "";
         if (exists(personinfo[2])) {
             focusperson = $(personinfo[2]).text().replace(/[\n\r]/g, " ").replace(/\s+/g, " ").trim();
+            focusperson = focusperson.replace(/ aka .*/i, "").trim();
             if (focusperson.contains("formerly")) {
                 focusperson = focusperson.replace("formerly", "(born") + ")";
             } else if (focusperson.contains("formerly") && focusperson.contains("[surname unknown]")) {
@@ -47,6 +49,7 @@ registerCollection({
 function parseWikiTree(htmlstring, familymembers, relation) {
     relation = relation || "";
     var parsed = $(htmlstring.replace(/<img/ig, "<gmi"));
+    parsed.find(".VITALS .EDIT, .VITALS .BLANK").remove();
     var focusdaterange = "";
     var title = parsed.filter('title').text();
     var focusrangearray = title.match(/\d* - \d*/);
@@ -66,6 +69,7 @@ function parseWikiTree(htmlstring, familymembers, relation) {
         $(personinfo[2]).html($(personinfo[2]).html().replace(/<strong>/gi, " "));
         focusperson = $(personinfo[2]).text().replace(/[\n\r]/g, " ").replace(/\s+/g, " ").trim();
         focusperson = focusperson.replace("[family name unknown]", "");
+        focusperson = focusperson.replace(/ aka .*/i, "").trim();
         if (focusperson.contains("formerly") && !focusperson.contains("[surname unknown]")) {
             focusperson = focusperson.replace("formerly", "(born") + ")";
         } else if (focusperson.contains("formerly") && focusperson.contains("[surname unknown]")) {
@@ -350,7 +354,7 @@ function parseWikiTree(htmlstring, familymembers, relation) {
 
 function parseWikiEvent(vitalstring) {
     var data = [];
-    var vitalinfo = vitalstring.trim().replace("[location unknown]", "").replace("[date unknown]", "").replace("[uncertain]","");
+    var vitalinfo = vitalstring.trim().replace(/\[[^\]]*\]/g, "").trim();
     const regin = /\sin /;
     var datesplit = vitalinfo.split(regin);
     if (datesplit.length > 0) {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "__MSG_appShortName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "4.13.2.0",
+    "version": "4.13.2.1",
     "icons": { "16": "images/icon16.png",
         "48": "images/icon48.png",
         "128": "images/icon128.png" },


### PR DESCRIPTION
## Summary

While testing #165 (the `.VITALS` index fix, `personinfo[4]` → `[2]`) against real profile pages, I found three additional parsing bugs in the same function, plus a merge regression that dropped some of #171's safety checks. This PR includes #165's index fix (both locations) as a prerequisite, plus:

- **"edit" leaking into the name field.** WikiTree injects `<span class="EDIT"><a>edit</a></span>` inside `.VITALS` blocks when the viewer has edit rights on the profile. Nothing stripped it before `.text()`, so it rode along into the name, e.g. `"Jette Löwenstein (born Wassermann aka Loewenstein edit)"`. Now stripped (`.VITALS .EDIT`, `.VITALS .BLANK`) before any text extraction.
- **Placeholder prompts leaking into date fields.** Incomplete records show prompts like `"[death date?]"` / `"[place of death?]"` instead of the three previously-hardcoded placeholder strings `parseWikiEvent` stripped (`[location unknown]`, `[date unknown]`, `[uncertain]`). Generalized to strip any bracketed placeholder text.
- **"aka" bleeding into the birth/maiden name.** The `aka` clause on a WikiTree profile documents alternate spellings of the *current* (married) surname, not the birth surname, but it was being appended to the parsed name, e.g. `"Weis Aka Loewenstein"` where `Loewenstein` is just an alternate spelling of the married name. Now dropped before the `"(born ...)"` name is built.
- **Restored 4 hunks from #171** (`response.source` null guard + `urlset.length` checks) that were lost when `pquenee-wikitree` (based on a pre-#171 commit) got merged. Without the `response.source` guard, `familystatus` never gets popped when a family member's page fails to fetch, which hangs `updateGeo()`'s poll loop indefinitely.

All four fixes were verified against a real WikiTree profile HTML snapshot by running `parseWikiTree` directly in a small Node/jsdom harness.

## Test plan
- [x] Verified `parseWikiTree` output against a real profile snapshot before/after each fix
- [x] Manual smoke test in the extension against a live WikiTree profile with edit rights and an incomplete death record

Depends on / includes #165.