### PR TITLE
Header-stripping rule robustness + menu link fixes (4.14.0.2)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -193,7 +193,7 @@
         "message": "Loading..."
     },
     "HistoryLink": {
-        "message": "HistoryLink"
+        "message": "HistoryLink Tools"
     },
     "Ancestor_Graph": {
         "message": "Ancestor Graph"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -192,6 +192,9 @@
     "Loading___": {
         "message": "Loading..."
     },
+    "HistoryLink": {
+        "message": "HistoryLink"
+    },
     "Ancestor_Graph": {
         "message": "Ancestor Graph"
     },
@@ -202,7 +205,7 @@
         "message": "History Search"
     },
     "Forest_Density_Calculator": {
-        "message": "Forest Density Calculator"
+        "message": "Density Calculator"
     },
     "Path_To_User": {
         "message": "Path to User"

--- a/background.js
+++ b/background.js
@@ -171,15 +171,31 @@ function exists(object) {
 
 const iframeHosts = ['www.geni.com',];
 
-chrome.runtime.onInstalled.addListener(() => {
-    // On Firefox, chrome.runtime.id is the browser_specific_settings.gecko.id
-    // from the manifest (an email-like string such as
-    // "smartcopy@eljeffeg.github.io"), not a Chrome-style extension id -
-    // declarativeNetRequest's initiatorDomains rejects it outright ("Invalid
-    // domain"), since it expects a plain hostname-shaped string. Wrapped in
-    // try/catch (and a .catch() for the promise itself) so a browser that
-    // can't set this specific rule just skips it, rather than throwing
-    // uncaught and leaving the header-stripping feature half-configured.
+// This rule strips X-Frame-Options/Frame-Options from geni.com responses,
+// but only for requests this extension itself initiates - it's what lets
+// #loginframe in popup.html actually render Geni's own login page in an
+// iframe (Geni sets X-Frame-Options: sameorigin, which blocks that by
+// default for every other origin). Without this rule installed, login
+// fails outright with "Refused to display ... because it set
+// 'X-Frame-Options' to 'sameorigin'".
+//
+// Previously only installed via chrome.runtime.onInstalled, which is a
+// one-time event on install/update. MV3 service workers get terminated and
+// restarted by Chrome frequently (idle timeout, browser restart, etc.), and
+// while declarativeNetRequest's dynamic rules are documented to persist
+// across those restarts, re-asserting the rule on every service worker
+// start as well is a cheap, idempotent safety net against any timing or
+// persistence edge case - not just the one moment right after an update.
+//
+// On Firefox, chrome.runtime.id is the browser_specific_settings.gecko.id
+// from the manifest (an email-like string such as
+// "smartcopy@eljeffeg.github.io"), not a Chrome-style extension id -
+// declarativeNetRequest's initiatorDomains rejects it outright ("Invalid
+// domain"), since it expects a plain hostname-shaped string. Wrapped in
+// try/catch (and a .catch() for the promise itself) so a browser that
+// can't set this specific rule just skips it, rather than throwing
+// uncaught and leaving the header-stripping feature half-configured.
+function installHeaderStrippingRule() {
     try {
         const RULE = {
           id: 1,
@@ -209,7 +225,10 @@ chrome.runtime.onInstalled.addListener(() => {
     } catch (error) {
         console.warn("Could not install header-stripping rule: ", error);
     }
-  });
+}
+
+chrome.runtime.onInstalled.addListener(installHeaderStrippingRule);
+installHeaderStrippingRule();
 
 
 let creating; // A global promise to avoid concurrency issues

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "__MSG_appShortName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "4.14.0.1",
+    "version": "4.14.0.2",
     "icons": { "16": "images/icon16.png",
         "48": "images/icon48.png",
         "128": "images/icon128.png" },

--- a/popup.html
+++ b/popup.html
@@ -20,16 +20,16 @@
         <div style="background-color:#e5ebf0; font-size: 82%; vertical-align: middle; margin: -2px -8px; padding: 2px 10px 4px; text-align: left; display: flex; justify-content: space-between; align-items: flex-start;">
             <div>
                 <div style="margin-right: 8px; padding-left: 5px;"><strong><a
-                        href="https://historylinktools.herokuapp.com/" style="color:#000;" target="_blank" id="historylinkurl" data-i18n="HistoryLink">HistoryLink</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
-                        href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
-                    Search</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
-                        href="https://historylinktools.herokuapp.com/graph?color=gender" style="color:#000;" target="_blank" id="graphurl" data-i18n="Ancestor_Graph">Ancestor
-                    Graph</a></strong></div>
-                <div style="margin-right: 8px; padding-left: 5px;"><strong><a
-                        href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
-                        id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://historylinktools.herokuapp.com/" style="color:#000;" target="_blank" id="historylinkurl" data-i18n="HistoryLink">HistoryLink Tools</a>: <a
                         href="https://gfdc-847976dd14c0.herokuapp.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Density
                     Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
+                        id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
+                    Search</a></strong></div>
+                <div style="margin-right: 8px; padding-left: 5px;"><strong><a
+                        href="https://historylinktools.herokuapp.com/graph?color=gender" style="color:#000;" target="_blank" id="graphurl" data-i18n="Ancestor_Graph">Ancestor
+                    Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                         href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path
                     to User</a></strong></div>
             </div>

--- a/popup.html
+++ b/popup.html
@@ -20,7 +20,7 @@
         <div style="background-color:#e5ebf0; font-size: 82%; vertical-align: middle; margin: -2px -8px; padding: 2px 10px 4px; text-align: left; display: flex; justify-content: space-between; align-items: flex-start;">
             <div>
                 <div style="margin-right: 8px; padding-left: 5px;"><strong><a
-                        href="https://historylinktools.herokuapp.com/" style="color:#000;" target="_blank" id="historylinkurl" data-i18n="HistoryLink">HistoryLink Tools</a>: <a
+                        href="https://historylinktools.herokuapp.com/" style="color:#000;" target="_blank" id="historylinkurl" data-i18n="HistoryLink">HistoryLink Tools</a>:&nbsp; <a
                         href="https://gfdc-847976dd14c0.herokuapp.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Density
                     Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                         href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History

--- a/popup.html
+++ b/popup.html
@@ -20,15 +20,16 @@
         <div style="background-color:#e5ebf0; font-size: 82%; vertical-align: middle; margin: -2px -8px; padding: 2px 10px 4px; text-align: left; display: flex; justify-content: space-between; align-items: flex-start;">
             <div>
                 <div style="margin-right: 8px; padding-left: 5px;"><strong><a
+                        href="https://historylinktools.herokuapp.com/" style="color:#000;" target="_blank" id="historylinkurl" data-i18n="HistoryLink">HistoryLink</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
+                    Search</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                         href="https://historylinktools.herokuapp.com/graph?color=gender" style="color:#000;" target="_blank" id="graphurl" data-i18n="Ancestor_Graph">Ancestor
-                    Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                    Graph</a></strong></div>
+                <div style="margin-right: 8px; padding-left: 5px;"><strong><a
                         href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
                         id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
-                        href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
-                    Search</a></strong></div>
-                <div style="margin-right: 8px; padding-left: 5px;"><strong><a
-                        href="http://gfdc.wnx.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Forest
-                    Density Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://gfdc-847976dd14c0.herokuapp.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Density
+                    Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                         href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path
                     to User</a></strong></div>
             </div>

--- a/popup.html
+++ b/popup.html
@@ -23,13 +23,13 @@
                         href="https://historylinktools.herokuapp.com/" style="color:#000;" target="_blank" id="historylinkurl" data-i18n="HistoryLink">HistoryLink Tools</a>: <a
                         href="https://gfdc-847976dd14c0.herokuapp.com/" style="color:#000;" target="_blank" id="forestdensityurl" data-i18n="Forest_Density_Calculator">Density
                     Calculator</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
-                        href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
-                        id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                         href="https://historylinktools.herokuapp.com/history" style="color:#000;" target="_blank" id="historyurl" data-i18n="History_Search">History
                     Search</a></strong></div>
                 <div style="margin-right: 8px; padding-left: 5px;"><strong><a
                         href="https://historylinktools.herokuapp.com/graph?color=gender" style="color:#000;" target="_blank" id="graphurl" data-i18n="Ancestor_Graph">Ancestor
                     Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
+                        href="https://historylinktools.herokuapp.com/graph?type=descendant&color=gender" style="color:#000;" target="_blank"
+                        id="descendanturl" data-i18n="Descendant_Graph">Descendant Graph</a> <span style="color:#000;">&nbsp;&bull;&nbsp;</span> <a
                         href="https://path-to-user.herokuapp.com/" style="color:#000;" target="_blank" id="pathtouserurl" data-i18n="Path_To_User">Path
                     to User</a></strong></div>
             </div>


### PR DESCRIPTION
## Summary

Two independent fixes, bundled together for a single 4.14.0.2 release:

### 1. Investigating a login failure report (Randy, Chrome, store build)

Jeff saw `Refused to display 'https://www.geni.com/' in a frame because it set 'X-Frame-Options' to 'sameorigin'` in the console. That's exactly what happens if the `declarativeNetRequest` rule that strips `X-Frame-Options` from geni.com responses (for this extension's own requests only) isn't in place - `#loginframe` in `popup.html` loads Geni's own login page directly in an iframe, which Geni's `X-Frame-Options: sameorigin` blocks by default for every other origin.

That rule's content is unchanged from before #181 - byte-identical on Chrome, and "Header rule installed" did log successfully in earlier testing - so this doesn't look like a regression in the rule itself. But it was only ever installed via `chrome.runtime.onInstalled`, a one-time event on install/update. MV3 service workers get killed and restarted by Chrome frequently, and while dynamic `declarativeNetRequest` rules are documented to persist across those restarts, there was no re-assertion of the rule anywhere else.

Fix: extracted the rule-install logic into a named function, called both from `onInstalled` and unconditionally at the script's top level (runs every service worker start, not just install/update). Cheap and idempotent.

**Caveat, unchanged from before:** Jeff couldn't reproduce Randy's exact issue either, so I can't confirm this is the same root cause - but it's a real, defensible robustness fix regardless, with no downside even if it turns out to not be the cause.

### 2. Menu link fixes

- The "Density Calculator" link (renamed from "Forest Density Calculator") was pointing to a dead `http://gfdc.wnx.com/` - corrected to `https://gfdc-847976dd14c0.herokuapp.com/`.
- Added a "HistoryLink" link to `https://historylinktools.herokuapp.com/`, the home/landing page for all of these tools - it wasn't linked anywhere before, only its sub-pages were (`/graph`, `/history`, `/leaderboard`).
- Reorganized the two menu rows to fit the new link: HistoryLink / History Search / Ancestor Graph on the first row, Descendant Graph / Density Calculator / Path to User on the second.

Version bumped to 4.14.0.2 to cover both.

Built on top of Jeff's `74c93c2` (gecko id + 4.14.0.1 version bump), already on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)